### PR TITLE
added support for using message digest of the header and payload to g…

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ This is a library to use with JavaScript source, not a CLI tool.
 const { signJwt, verifyJwt } = require('aws-kms-jwt');
 
 const main = async () => {
-    const signedToken = await signJwt({ foo: 'bar' }, process.env.CMK_ALIAS);
+    const signedToken = await signJwt({ foo: 'bar' }, process.env.CMK_ALIAS, { useDigest: true });  // optional useDigest flag to use message digest hashing for signing and verifying
     console.log(signedToken);
 
-    const verifiedToken = await verifyJwt(signedToken);
+    const verifiedToken = await verifyJwt(signedToken, { useDigest: true });
     console.log(verifiedToken);
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-kms-jwt",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "description": "AWS KMS Lib for signing/verifying JWT",
   "main": "./lib/index.js",
   "files": [

--- a/src/index.js
+++ b/src/index.js
@@ -2,4 +2,4 @@ import Connector from './connector';
 
 export const signJwt = (jwt, masterKeyAlias, options) => new Connector(masterKeyAlias).sign(jwt, options);
 
-export const verifyJwt = (jwt) => new Connector().verify(jwt);
+export const verifyJwt = (jwt, options) => new Connector().verify(jwt, options);

--- a/test/int/index.test.js
+++ b/test/int/index.test.js
@@ -25,4 +25,11 @@ describe('index.js', () => {
 
     expect(verifiedToken.foo).equal('bar');
   });
+
+  it('should verify token signed with message digest', async () => {
+    const signedToken = await signJwt({ foo: 'bar' }, process.env.CMK_ALIAS, { useDigest: true });
+    const verifiedToken = await verifyJwt(signedToken, { useDigest: true });
+
+    expect(verifiedToken.foo).equal('bar');
+  });
 });

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -37,6 +37,19 @@ describe('index.js', () => {
     expect(response).to.deep.equal(SIGNED_JWT_WITH_EXP);
   });
 
+  it('should sign jwt with options using digest', async () => {
+    const jwt = { foo: 'bar' };
+    const options = { expires: new Date(), useDigest: true };
+
+    sinon.stub(Connector.prototype, 'sign')
+      .withArgs(jwt, options)
+      .returns(Promise.resolve(SIGNED_JWT_WITH_EXP));
+
+    const response = await signJwt(jwt, 'masterKeyAlias', options);
+
+    expect(response).to.deep.equal(SIGNED_JWT_WITH_EXP);
+  });
+
   it('should verify jwt', async () => {
     const jwt = { foo: 'bar' };
     sinon.stub(Connector.prototype, 'verify')
@@ -44,6 +57,16 @@ describe('index.js', () => {
       .returns(Promise.resolve(jwt));
 
     const response = await verifyJwt(jwt);
+
+    expect(response).to.deep.equal(jwt);
+  });
+  it('should verify jwt with option useDigest', async () => {
+    const jwt = { foo: 'bar' };
+    sinon.stub(Connector.prototype, 'verify')
+      .withArgs(jwt)
+      .returns(Promise.resolve(jwt));
+
+    const response = await verifyJwt(jwt, { useDigest: true });
 
     expect(response).to.deep.equal(jwt);
   });


### PR DESCRIPTION
…enerate signature to overcome 4k aws kms encrypt limit. Optional useDigest flag can be provided in both signJwt and verifyJwt requests